### PR TITLE
Switch from JSON::XS to JSON::MaybeXS

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -10,10 +10,10 @@ my $builder = Module::Build->new(
     dist_author         => 'Jozef Kutej <jkutej@cpan.org>',
     dist_version_from   => 'lib/JSON/Util.pm',
     requires => {
-        'Scalar::Util' => 0,
-        'IO::Any'      => 0,
-        'Carp'         => 0,
-        'JSON::XS'     => 0,
+        'Scalar::Util'  => 0,
+        'IO::Any'       => 0,
+        'Carp'          => 0,
+        'JSON::MaybeXS' => 0,
     },
     build_requires => {
         'Test::More'        => 0,

--- a/lib/JSON/Util.pm
+++ b/lib/JSON/Util.pm
@@ -41,7 +41,7 @@ use feature 'state';
 use Scalar::Util 'blessed';
 use IO::Any;
 use Carp 'croak';
-use JSON::XS;
+use JSON::MaybeXS;
 
 =head1 METHODS
 
@@ -49,7 +49,7 @@ use JSON::XS;
 
 Object constructor. Needed only when the L</default_json> configuration
 needs to be changed. Any key/value passed as parameter will be called on
-C<<JSON::XS->new()>> as C<<$json->$key($value)>>.
+C<<JSON::MaybeXS->new()>> as C<<$json->$key($value)>>.
 
 =cut
 
@@ -64,7 +64,7 @@ sub new {
 
     my $self  = bless \%options, __PACKAGE__;
     
-    my $json = JSON::XS->new();
+    my $json = JSON::MaybeXS->new();
     while (my ($option, $value) = each %options) {
         $json->$option($value);
     }
@@ -76,7 +76,7 @@ sub new {
 
 =head2 default_json
 
-Returns C<<JSON::XS->new()>> with:
+Returns C<<JSON::MaybeXS->new()>> with:
 
         'utf8'            => 1,
         'pretty'          => 1,
@@ -92,7 +92,7 @@ sub default_json {
 
 =head2 json
 
-Returns current L<JSON::XS> object.
+Returns current L<JSON::MaybeXS> object.
 
 =cut
 

--- a/t/01_JSON-Util.t
+++ b/t/01_JSON-Util.t
@@ -10,6 +10,7 @@ use Test::More tests => 8;
 use Test::Differences;
 use File::Temp 'tempdir';
 use IO::Any;
+use JSON::MaybeXS;
 use Test::Exception;
 
 use FindBin '$Bin';
@@ -21,7 +22,7 @@ BEGIN {
 exit main();
 
 sub main {
-	my $jsonxs = JSON::XS->new->utf8->pretty->convert_blessed;
+	my $jsonxs = JSON::MaybeXS->new->utf8->pretty->convert_blessed;
 	my $tmpdir = tempdir( CLEANUP => 1 );
 	
 	my $utf8_data = [


### PR DESCRIPTION
Trivial search-and-replace swapping JSON::MaybeXS in for JSON::XS. Provides the flexibility of using this module with JSON::PP (should anybody want to do that) or Cpanel::JSON::XS for those wanting to avoid JSON::XS usage.
